### PR TITLE
feat: add grading domain models

### DIFF
--- a/core/api/views/attendance_code_views.py
+++ b/core/api/views/attendance_code_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.attendance_code_serializer import AttendanceCodeSerializer
+from core.container import Container
+
+
+class AttendanceCodeViewSet(ViewSet):
+    """ViewSet for managing attendance codes."""
+    serializer_class = AttendanceCodeSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_attendance_code_service = Container.create_attendance_code_service()
+        self.delete_attendance_code_service = Container.delete_attendance_code_service()
+        self.get_attendance_code_service = Container.get_attendance_code_service()
+        self.list_attendance_code_service = Container.list_attendance_code_service()
+        self.update_attendance_code_service = Container.update_attendance_code_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        attendance_code = self.create_attendance_code_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(attendance_code).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        attendance_codes = self.list_attendance_code_service.execute()
+        paginator = StandardResultsSetPagination(request, attendance_codes)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        attendance_code = self.get_attendance_code_service.execute(pk)
+        serializer = self.serializer_class(attendance_code)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        attendance_code = self.update_attendance_code_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(attendance_code).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_attendance_code_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/api/views/behavior_scale_views.py
+++ b/core/api/views/behavior_scale_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.behavior_scale_serializer import BehaviorScaleSerializer
+from core.container import Container
+
+
+class BehaviorScaleViewSet(ViewSet):
+    """ViewSet for managing behavior scales."""
+    serializer_class = BehaviorScaleSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_behavior_scale_service = Container.create_behavior_scale_service()
+        self.delete_behavior_scale_service = Container.delete_behavior_scale_service()
+        self.get_behavior_scale_service = Container.get_behavior_scale_service()
+        self.list_behavior_scale_service = Container.list_behavior_scale_service()
+        self.update_behavior_scale_service = Container.update_behavior_scale_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        behavior_scale = self.create_behavior_scale_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(behavior_scale).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        behavior_scales = self.list_behavior_scale_service.execute()
+        paginator = StandardResultsSetPagination(request, behavior_scales)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        behavior_scale = self.get_behavior_scale_service.execute(pk)
+        serializer = self.serializer_class(behavior_scale)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        behavior_scale = self.update_behavior_scale_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(behavior_scale).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_behavior_scale_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/api/views/evaluation_type_views.py
+++ b/core/api/views/evaluation_type_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.evaluation_type_serializer import EvaluationTypeSerializer
+from core.container import Container
+
+
+class EvaluationTypeViewSet(ViewSet):
+    """ViewSet for managing evaluation types."""
+    serializer_class = EvaluationTypeSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_evaluation_type_service = Container.create_evaluation_type_service()
+        self.delete_evaluation_type_service = Container.delete_evaluation_type_service()
+        self.get_evaluation_type_service = Container.get_evaluation_type_service()
+        self.list_evaluation_type_service = Container.list_evaluation_type_service()
+        self.update_evaluation_type_service = Container.update_evaluation_type_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        evaluation_type = self.create_evaluation_type_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(evaluation_type).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        evaluation_types = self.list_evaluation_type_service.execute()
+        paginator = StandardResultsSetPagination(request, evaluation_types)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        evaluation_type = self.get_evaluation_type_service.execute(pk)
+        serializer = self.serializer_class(evaluation_type)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        evaluation_type = self.update_evaluation_type_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(evaluation_type).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_evaluation_type_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/api/views/grading_system_views.py
+++ b/core/api/views/grading_system_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.grading_system_serializer import GradingSystemSerializer
+from core.container import Container
+
+
+class GradingSystemViewSet(ViewSet):
+    """ViewSet for managing grading systems."""
+    serializer_class = GradingSystemSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_grading_system_service = Container.create_grading_system_service()
+        self.delete_grading_system_service = Container.delete_grading_system_service()
+        self.get_grading_system_service = Container.get_grading_system_service()
+        self.list_grading_system_service = Container.list_grading_system_service()
+        self.update_grading_system_service = Container.update_grading_system_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        grading_system = self.create_grading_system_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(grading_system).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        grading_systems = self.list_grading_system_service.execute()
+        paginator = StandardResultsSetPagination(request, grading_systems)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        grading_system = self.get_grading_system_service.execute(pk)
+        serializer = self.serializer_class(grading_system)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        grading_system = self.update_grading_system_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(grading_system).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_grading_system_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/api/views/grading_term_views.py
+++ b/core/api/views/grading_term_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.grading_term_serializer import GradingTermSerializer
+from core.container import Container
+
+
+class GradingTermViewSet(ViewSet):
+    """ViewSet for managing grading terms."""
+    serializer_class = GradingTermSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_grading_term_service = Container.create_grading_term_service()
+        self.delete_grading_term_service = Container.delete_grading_term_service()
+        self.get_grading_term_service = Container.get_grading_term_service()
+        self.list_grading_term_service = Container.list_grading_term_service()
+        self.update_grading_term_service = Container.update_grading_term_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        grading_term = self.create_grading_term_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(grading_term).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        grading_terms = self.list_grading_term_service.execute()
+        paginator = StandardResultsSetPagination(request, grading_terms)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        grading_term = self.get_grading_term_service.execute(pk)
+        serializer = self.serializer_class(grading_term)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        grading_term = self.update_grading_term_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(grading_term).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_grading_term_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/api/views/meeting_type_views.py
+++ b/core/api/views/meeting_type_views.py
@@ -1,0 +1,48 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status
+
+from core.api.configuration.pagination import StandardResultsSetPagination
+from core.application.serializers.meeting_type_serializer import MeetingTypeSerializer
+from core.container import Container
+
+
+class MeetingTypeViewSet(ViewSet):
+    """ViewSet for managing meeting types."""
+    serializer_class = MeetingTypeSerializer
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.create_meeting_type_service = Container.create_meeting_type_service()
+        self.delete_meeting_type_service = Container.delete_meeting_type_service()
+        self.get_meeting_type_service = Container.get_meeting_type_service()
+        self.list_meeting_type_service = Container.list_meeting_type_service()
+        self.update_meeting_type_service = Container.update_meeting_type_service()
+
+    def create(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        meeting_type = self.create_meeting_type_service.execute(**serializer.validated_data)
+        return Response(self.serializer_class(meeting_type).data, status=status.HTTP_201_CREATED)
+
+    def list(self, request):
+        meeting_types = self.list_meeting_type_service.execute()
+        paginator = StandardResultsSetPagination(request, meeting_types)
+        paginated_data = paginator.paginate_queryset()
+        serializer = self.serializer_class(paginated_data, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        meeting_type = self.get_meeting_type_service.execute(pk)
+        serializer = self.serializer_class(meeting_type)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, pk=None):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        meeting_type = self.update_meeting_type_service.execute(pk, **serializer.validated_data)
+        return Response(self.serializer_class(meeting_type).data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        self.delete_meeting_type_service.execute(pk)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/core/application/serializers/attendance_code_serializer.py
+++ b/core/application/serializers/attendance_code_serializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+
+class AttendanceCodeSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    code = serializers.CharField(max_length=10)
+    description = serializers.CharField(max_length=255)
+    affectsGrade = serializers.BooleanField(default=False)

--- a/core/application/serializers/behavior_scale_serializer.py
+++ b/core/application/serializers/behavior_scale_serializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+
+class BehaviorScaleSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(max_length=255)
+    minScore = serializers.DecimalField(max_digits=5, decimal_places=2)
+    maxScore = serializers.DecimalField(max_digits=5, decimal_places=2)

--- a/core/application/serializers/evaluation_type_serializer.py
+++ b/core/application/serializers/evaluation_type_serializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+
+class EvaluationTypeSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(max_length=255)
+    description = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    weight = serializers.DecimalField(max_digits=5, decimal_places=2)

--- a/core/application/serializers/grading_system_serializer.py
+++ b/core/application/serializers/grading_system_serializer.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+class GradingSystemSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(max_length=255)
+    description = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    numberOfTerms = serializers.IntegerField()
+    passingScore = serializers.DecimalField(max_digits=5, decimal_places=2)

--- a/core/application/serializers/grading_term_serializer.py
+++ b/core/application/serializers/grading_term_serializer.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+class GradingTermSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    gradingSystem_id = serializers.IntegerField()
+    academicYear_id = serializers.IntegerField()
+    name = serializers.CharField(max_length=255)
+    order = serializers.IntegerField()
+    weight = serializers.DecimalField(max_digits=5, decimal_places=2)

--- a/core/application/serializers/meeting_type_serializer.py
+++ b/core/application/serializers/meeting_type_serializer.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+class MeetingTypeSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(max_length=255)
+    description = serializers.CharField(allow_null=True, allow_blank=True, required=False)

--- a/core/application/services/attendance_codes/create_attendance_code_service.py
+++ b/core/application/services/attendance_codes/create_attendance_code_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.attendance_code import AttendanceCode
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from rest_framework.exceptions import ValidationError
+
+class CreateAttendanceCodeService:
+    def __init__(self, attendance_code_repository: AttendanceCodeRepository):
+        self.attendance_code_repository = attendance_code_repository
+
+    def execute(self, code, description, affectsGrade=False):
+        if self.attendance_code_repository.exist_by_code(code):
+            raise ValidationError("Attendance code with this code already exists.")
+        attendance_code = AttendanceCode(
+            id=None,
+            code=code,
+            description=description,
+            affectsGrade=affectsGrade,
+        )
+        return self.attendance_code_repository.create(attendance_code)

--- a/core/application/services/attendance_codes/delete_attendance_code_service.py
+++ b/core/application/services/attendance_codes/delete_attendance_code_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteAttendanceCodeService:
+    def __init__(self, attendance_code_repository: AttendanceCodeRepository):
+        self.attendance_code_repository = attendance_code_repository
+
+    def execute(self, attendance_code_id: int):
+        if not self.attendance_code_repository.exist_by_id(attendance_code_id):
+            raise NotFound("Attendance code not found")
+        return self.attendance_code_repository.delete(attendance_code_id)

--- a/core/application/services/attendance_codes/get_attendance_code_service.py
+++ b/core/application/services/attendance_codes/get_attendance_code_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from rest_framework.exceptions import NotFound
+
+class GetAttendanceCodeService:
+    def __init__(self, attendance_code_repository: AttendanceCodeRepository):
+        self.attendance_code_repository = attendance_code_repository
+
+    def execute(self, attendance_code_id: int):
+        if not self.attendance_code_repository.exist_by_id(attendance_code_id):
+            raise NotFound("Attendance code not found")
+        return self.attendance_code_repository.get(attendance_code_id)

--- a/core/application/services/attendance_codes/list_attendance_code_service.py
+++ b/core/application/services/attendance_codes/list_attendance_code_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListAttendanceCodeService:
+    def __init__(self, attendance_code_repository: AttendanceCodeRepository):
+        self.attendance_code_repository = attendance_code_repository
+
+    def execute(self):
+        try:
+            return self.attendance_code_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing attendance codes: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No attendance codes found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid attendance code data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/attendance_codes/update_attendance_code_service.py
+++ b/core/application/services/attendance_codes/update_attendance_code_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.attendance_code import AttendanceCode
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateAttendanceCodeService:
+    def __init__(self, attendance_code_repository: AttendanceCodeRepository):
+        self.attendance_code_repository = attendance_code_repository
+
+    def execute(self, attendance_code_id: int, code, description, affectsGrade=False):
+        if not self.attendance_code_repository.exist_by_id(attendance_code_id):
+            raise NotFound("Attendance code not found")
+        attendance_code = AttendanceCode(
+            id=attendance_code_id,
+            code=code,
+            description=description,
+            affectsGrade=affectsGrade,
+        )
+        return self.attendance_code_repository.update(attendance_code)

--- a/core/application/services/behavior_scales/create_behavior_scale_service.py
+++ b/core/application/services/behavior_scales/create_behavior_scale_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.behavior_scale import BehaviorScale
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from rest_framework.exceptions import ValidationError
+
+class CreateBehaviorScaleService:
+    def __init__(self, behavior_scale_repository: BehaviorScaleRepository):
+        self.behavior_scale_repository = behavior_scale_repository
+
+    def execute(self, name, minScore, maxScore):
+        if self.behavior_scale_repository.exist_by_name(name):
+            raise ValidationError("Behavior scale with this name already exists.")
+        behavior_scale = BehaviorScale(
+            id=None,
+            name=name,
+            minScore=minScore,
+            maxScore=maxScore,
+        )
+        return self.behavior_scale_repository.create(behavior_scale)

--- a/core/application/services/behavior_scales/delete_behavior_scale_service.py
+++ b/core/application/services/behavior_scales/delete_behavior_scale_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteBehaviorScaleService:
+    def __init__(self, behavior_scale_repository: BehaviorScaleRepository):
+        self.behavior_scale_repository = behavior_scale_repository
+
+    def execute(self, behavior_scale_id: int):
+        if not self.behavior_scale_repository.exist_by_id(behavior_scale_id):
+            raise NotFound("Behavior scale not found")
+        return self.behavior_scale_repository.delete(behavior_scale_id)

--- a/core/application/services/behavior_scales/get_behavior_scale_service.py
+++ b/core/application/services/behavior_scales/get_behavior_scale_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from rest_framework.exceptions import NotFound
+
+class GetBehaviorScaleService:
+    def __init__(self, behavior_scale_repository: BehaviorScaleRepository):
+        self.behavior_scale_repository = behavior_scale_repository
+
+    def execute(self, behavior_scale_id: int):
+        if not self.behavior_scale_repository.exist_by_id(behavior_scale_id):
+            raise NotFound("Behavior scale not found")
+        return self.behavior_scale_repository.get(behavior_scale_id)

--- a/core/application/services/behavior_scales/list_behavior_scale_service.py
+++ b/core/application/services/behavior_scales/list_behavior_scale_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListBehaviorScaleService:
+    def __init__(self, behavior_scale_repository: BehaviorScaleRepository):
+        self.behavior_scale_repository = behavior_scale_repository
+
+    def execute(self):
+        try:
+            return self.behavior_scale_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing behavior scales: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No behavior scales found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid behavior scale data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/behavior_scales/update_behavior_scale_service.py
+++ b/core/application/services/behavior_scales/update_behavior_scale_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.behavior_scale import BehaviorScale
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateBehaviorScaleService:
+    def __init__(self, behavior_scale_repository: BehaviorScaleRepository):
+        self.behavior_scale_repository = behavior_scale_repository
+
+    def execute(self, behavior_scale_id: int, name, minScore, maxScore):
+        if not self.behavior_scale_repository.exist_by_id(behavior_scale_id):
+            raise NotFound("Behavior scale not found")
+        behavior_scale = BehaviorScale(
+            id=behavior_scale_id,
+            name=name,
+            minScore=minScore,
+            maxScore=maxScore,
+        )
+        return self.behavior_scale_repository.update(behavior_scale)

--- a/core/application/services/evaluation_types/create_evaluation_type_service.py
+++ b/core/application/services/evaluation_types/create_evaluation_type_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.evaluation_type import EvaluationType
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from rest_framework.exceptions import ValidationError
+
+class CreateEvaluationTypeService:
+    def __init__(self, evaluation_type_repository: EvaluationTypeRepository):
+        self.evaluation_type_repository = evaluation_type_repository
+
+    def execute(self, name, description, weight):
+        if self.evaluation_type_repository.exist_by_name(name):
+            raise ValidationError("Evaluation type with this name already exists.")
+        evaluation_type = EvaluationType(
+            id=None,
+            name=name,
+            description=description,
+            weight=weight,
+        )
+        return self.evaluation_type_repository.create(evaluation_type)

--- a/core/application/services/evaluation_types/delete_evaluation_type_service.py
+++ b/core/application/services/evaluation_types/delete_evaluation_type_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteEvaluationTypeService:
+    def __init__(self, evaluation_type_repository: EvaluationTypeRepository):
+        self.evaluation_type_repository = evaluation_type_repository
+
+    def execute(self, evaluation_type_id: int):
+        if not self.evaluation_type_repository.exist_by_id(evaluation_type_id):
+            raise NotFound("Evaluation type not found")
+        return self.evaluation_type_repository.delete(evaluation_type_id)

--- a/core/application/services/evaluation_types/get_evaluation_type_service.py
+++ b/core/application/services/evaluation_types/get_evaluation_type_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from rest_framework.exceptions import NotFound
+
+class GetEvaluationTypeService:
+    def __init__(self, evaluation_type_repository: EvaluationTypeRepository):
+        self.evaluation_type_repository = evaluation_type_repository
+
+    def execute(self, evaluation_type_id: int):
+        if not self.evaluation_type_repository.exist_by_id(evaluation_type_id):
+            raise NotFound("Evaluation type not found")
+        return self.evaluation_type_repository.get(evaluation_type_id)

--- a/core/application/services/evaluation_types/list_evaluation_type_service.py
+++ b/core/application/services/evaluation_types/list_evaluation_type_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListEvaluationTypeService:
+    def __init__(self, evaluation_type_repository: EvaluationTypeRepository):
+        self.evaluation_type_repository = evaluation_type_repository
+
+    def execute(self):
+        try:
+            return self.evaluation_type_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing evaluation types: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No evaluation types found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid evaluation type data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/evaluation_types/update_evaluation_type_service.py
+++ b/core/application/services/evaluation_types/update_evaluation_type_service.py
@@ -1,0 +1,18 @@
+from core.domain.entities.evaluation_type import EvaluationType
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateEvaluationTypeService:
+    def __init__(self, evaluation_type_repository: EvaluationTypeRepository):
+        self.evaluation_type_repository = evaluation_type_repository
+
+    def execute(self, evaluation_type_id: int, name, description, weight):
+        if not self.evaluation_type_repository.exist_by_id(evaluation_type_id):
+            raise NotFound("Evaluation type not found")
+        evaluation_type = EvaluationType(
+            id=evaluation_type_id,
+            name=name,
+            description=description,
+            weight=weight,
+        )
+        return self.evaluation_type_repository.update(evaluation_type)

--- a/core/application/services/grading_systems/create_grading_system_service.py
+++ b/core/application/services/grading_systems/create_grading_system_service.py
@@ -1,0 +1,19 @@
+from core.domain.entities.grading_system import GradingSystem
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from rest_framework.exceptions import ValidationError
+
+class CreateGradingSystemService:
+    def __init__(self, grading_system_repository: GradingSystemRepository):
+        self.grading_system_repository = grading_system_repository
+
+    def execute(self, name, description, numberOfTerms, passingScore):
+        if self.grading_system_repository.exist_by_name(name):
+            raise ValidationError("Grading system with this name already exists.")
+        grading_system = GradingSystem(
+            id=None,
+            name=name,
+            description=description,
+            numberOfTerms=numberOfTerms,
+            passingScore=passingScore,
+        )
+        return self.grading_system_repository.create(grading_system)

--- a/core/application/services/grading_systems/delete_grading_system_service.py
+++ b/core/application/services/grading_systems/delete_grading_system_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteGradingSystemService:
+    def __init__(self, grading_system_repository: GradingSystemRepository):
+        self.grading_system_repository = grading_system_repository
+
+    def execute(self, grading_system_id: int):
+        if not self.grading_system_repository.exist_by_id(grading_system_id):
+            raise NotFound("Grading system not found")
+        return self.grading_system_repository.delete(grading_system_id)

--- a/core/application/services/grading_systems/get_grading_system_service.py
+++ b/core/application/services/grading_systems/get_grading_system_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from rest_framework.exceptions import NotFound
+
+class GetGradingSystemService:
+    def __init__(self, grading_system_repository: GradingSystemRepository):
+        self.grading_system_repository = grading_system_repository
+
+    def execute(self, grading_system_id: int):
+        if not self.grading_system_repository.exist_by_id(grading_system_id):
+            raise NotFound("Grading system not found")
+        return self.grading_system_repository.get(grading_system_id)

--- a/core/application/services/grading_systems/list_grading_system_service.py
+++ b/core/application/services/grading_systems/list_grading_system_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListGradingSystemService:
+    def __init__(self, grading_system_repository: GradingSystemRepository):
+        self.grading_system_repository = grading_system_repository
+
+    def execute(self):
+        try:
+            return self.grading_system_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing grading systems: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No grading systems found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid grading system data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/grading_systems/update_grading_system_service.py
+++ b/core/application/services/grading_systems/update_grading_system_service.py
@@ -1,0 +1,19 @@
+from core.domain.entities.grading_system import GradingSystem
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateGradingSystemService:
+    def __init__(self, grading_system_repository: GradingSystemRepository):
+        self.grading_system_repository = grading_system_repository
+
+    def execute(self, grading_system_id: int, name, description, numberOfTerms, passingScore):
+        if not self.grading_system_repository.exist_by_id(grading_system_id):
+            raise NotFound("Grading system not found")
+        grading_system = GradingSystem(
+            id=grading_system_id,
+            name=name,
+            description=description,
+            numberOfTerms=numberOfTerms,
+            passingScore=passingScore,
+        )
+        return self.grading_system_repository.update(grading_system)

--- a/core/application/services/grading_terms/create_grading_term_service.py
+++ b/core/application/services/grading_terms/create_grading_term_service.py
@@ -1,0 +1,17 @@
+from core.domain.entities.grading_term import GradingTerm
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+
+class CreateGradingTermService:
+    def __init__(self, grading_term_repository: GradingTermRepository):
+        self.grading_term_repository = grading_term_repository
+
+    def execute(self, gradingSystem_id, academicYear_id, name, order, weight):
+        grading_term = GradingTerm(
+            id=None,
+            gradingSystem_id=gradingSystem_id,
+            academicYear_id=academicYear_id,
+            name=name,
+            order=order,
+            weight=weight,
+        )
+        return self.grading_term_repository.create(grading_term)

--- a/core/application/services/grading_terms/delete_grading_term_service.py
+++ b/core/application/services/grading_terms/delete_grading_term_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteGradingTermService:
+    def __init__(self, grading_term_repository: GradingTermRepository):
+        self.grading_term_repository = grading_term_repository
+
+    def execute(self, grading_term_id: int):
+        if not self.grading_term_repository.exist_by_id(grading_term_id):
+            raise NotFound("Grading term not found")
+        return self.grading_term_repository.delete(grading_term_id)

--- a/core/application/services/grading_terms/get_grading_term_service.py
+++ b/core/application/services/grading_terms/get_grading_term_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+from rest_framework.exceptions import NotFound
+
+class GetGradingTermService:
+    def __init__(self, grading_term_repository: GradingTermRepository):
+        self.grading_term_repository = grading_term_repository
+
+    def execute(self, grading_term_id: int):
+        if not self.grading_term_repository.exist_by_id(grading_term_id):
+            raise NotFound("Grading term not found")
+        return self.grading_term_repository.get(grading_term_id)

--- a/core/application/services/grading_terms/list_grading_term_service.py
+++ b/core/application/services/grading_terms/list_grading_term_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListGradingTermService:
+    def __init__(self, grading_term_repository: GradingTermRepository):
+        self.grading_term_repository = grading_term_repository
+
+    def execute(self):
+        try:
+            return self.grading_term_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing grading terms: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No grading terms found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid grading term data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/grading_terms/update_grading_term_service.py
+++ b/core/application/services/grading_terms/update_grading_term_service.py
@@ -1,0 +1,20 @@
+from core.domain.entities.grading_term import GradingTerm
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateGradingTermService:
+    def __init__(self, grading_term_repository: GradingTermRepository):
+        self.grading_term_repository = grading_term_repository
+
+    def execute(self, grading_term_id: int, gradingSystem_id, academicYear_id, name, order, weight):
+        if not self.grading_term_repository.exist_by_id(grading_term_id):
+            raise NotFound("Grading term not found")
+        grading_term = GradingTerm(
+            id=grading_term_id,
+            gradingSystem_id=gradingSystem_id,
+            academicYear_id=academicYear_id,
+            name=name,
+            order=order,
+            weight=weight,
+        )
+        return self.grading_term_repository.update(grading_term)

--- a/core/application/services/meeting_types/create_meeting_type_service.py
+++ b/core/application/services/meeting_types/create_meeting_type_service.py
@@ -1,0 +1,17 @@
+from core.domain.entities.meeting_type import MeetingType
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from rest_framework.exceptions import ValidationError
+
+class CreateMeetingTypeService:
+    def __init__(self, meeting_type_repository: MeetingTypeRepository):
+        self.meeting_type_repository = meeting_type_repository
+
+    def execute(self, name, description):
+        if self.meeting_type_repository.exist_by_name(name):
+            raise ValidationError("Meeting type with this name already exists.")
+        meeting_type = MeetingType(
+            id=None,
+            name=name,
+            description=description,
+        )
+        return self.meeting_type_repository.create(meeting_type)

--- a/core/application/services/meeting_types/delete_meeting_type_service.py
+++ b/core/application/services/meeting_types/delete_meeting_type_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from rest_framework.exceptions import NotFound
+
+class DeleteMeetingTypeService:
+    def __init__(self, meeting_type_repository: MeetingTypeRepository):
+        self.meeting_type_repository = meeting_type_repository
+
+    def execute(self, meeting_type_id: int):
+        if not self.meeting_type_repository.exist_by_id(meeting_type_id):
+            raise NotFound("Meeting type not found")
+        return self.meeting_type_repository.delete(meeting_type_id)

--- a/core/application/services/meeting_types/get_meeting_type_service.py
+++ b/core/application/services/meeting_types/get_meeting_type_service.py
@@ -1,0 +1,11 @@
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from rest_framework.exceptions import NotFound
+
+class GetMeetingTypeService:
+    def __init__(self, meeting_type_repository: MeetingTypeRepository):
+        self.meeting_type_repository = meeting_type_repository
+
+    def execute(self, meeting_type_id: int):
+        if not self.meeting_type_repository.exist_by_id(meeting_type_id):
+            raise NotFound("Meeting type not found")
+        return self.meeting_type_repository.get(meeting_type_id)

--- a/core/application/services/meeting_types/list_meeting_type_service.py
+++ b/core/application/services/meeting_types/list_meeting_type_service.py
@@ -1,0 +1,19 @@
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from rest_framework.exceptions import NotFound, ValidationError
+import logging
+
+class ListMeetingTypeService:
+    def __init__(self, meeting_type_repository: MeetingTypeRepository):
+        self.meeting_type_repository = meeting_type_repository
+
+    def execute(self):
+        try:
+            return self.meeting_type_repository.all()
+        except Exception as e:
+            logging.error(f"Error listing meeting types: {e}")
+            if isinstance(e, NotFound):
+                raise NotFound("No meeting types found")
+            elif isinstance(e, ValidationError):
+                raise ValidationError("Invalid meeting type data")
+            else:
+                raise Exception("An unexpected error occurred") from e

--- a/core/application/services/meeting_types/update_meeting_type_service.py
+++ b/core/application/services/meeting_types/update_meeting_type_service.py
@@ -1,0 +1,17 @@
+from core.domain.entities.meeting_type import MeetingType
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from rest_framework.exceptions import NotFound
+
+class UpdateMeetingTypeService:
+    def __init__(self, meeting_type_repository: MeetingTypeRepository):
+        self.meeting_type_repository = meeting_type_repository
+
+    def execute(self, meeting_type_id: int, name, description):
+        if not self.meeting_type_repository.exist_by_id(meeting_type_id):
+            raise NotFound("Meeting type not found")
+        meeting_type = MeetingType(
+            id=meeting_type_id,
+            name=name,
+            description=description,
+        )
+        return self.meeting_type_repository.update(meeting_type)

--- a/core/container.py
+++ b/core/container.py
@@ -38,6 +38,36 @@ from core.application.services.subjects.delete_subject_service import DeleteSubj
 from core.application.services.subjects.get_subject_service import GetSubjectService
 from core.application.services.subjects.list_subject_service import ListSubjectService
 from core.application.services.subjects.update_subject_service import UpdateSubjectService
+from core.application.services.grading_systems.create_grading_system_service import CreateGradingSystemService
+from core.application.services.grading_systems.delete_grading_system_service import DeleteGradingSystemService
+from core.application.services.grading_systems.get_grading_system_service import GetGradingSystemService
+from core.application.services.grading_systems.list_grading_system_service import ListGradingSystemService
+from core.application.services.grading_systems.update_grading_system_service import UpdateGradingSystemService
+from core.application.services.grading_terms.create_grading_term_service import CreateGradingTermService
+from core.application.services.grading_terms.delete_grading_term_service import DeleteGradingTermService
+from core.application.services.grading_terms.get_grading_term_service import GetGradingTermService
+from core.application.services.grading_terms.list_grading_term_service import ListGradingTermService
+from core.application.services.grading_terms.update_grading_term_service import UpdateGradingTermService
+from core.application.services.evaluation_types.create_evaluation_type_service import CreateEvaluationTypeService
+from core.application.services.evaluation_types.delete_evaluation_type_service import DeleteEvaluationTypeService
+from core.application.services.evaluation_types.get_evaluation_type_service import GetEvaluationTypeService
+from core.application.services.evaluation_types.list_evaluation_type_service import ListEvaluationTypeService
+from core.application.services.evaluation_types.update_evaluation_type_service import UpdateEvaluationTypeService
+from core.application.services.meeting_types.create_meeting_type_service import CreateMeetingTypeService
+from core.application.services.meeting_types.delete_meeting_type_service import DeleteMeetingTypeService
+from core.application.services.meeting_types.get_meeting_type_service import GetMeetingTypeService
+from core.application.services.meeting_types.list_meeting_type_service import ListMeetingTypeService
+from core.application.services.meeting_types.update_meeting_type_service import UpdateMeetingTypeService
+from core.application.services.attendance_codes.create_attendance_code_service import CreateAttendanceCodeService
+from core.application.services.attendance_codes.delete_attendance_code_service import DeleteAttendanceCodeService
+from core.application.services.attendance_codes.get_attendance_code_service import GetAttendanceCodeService
+from core.application.services.attendance_codes.list_attendance_code_service import ListAttendanceCodeService
+from core.application.services.attendance_codes.update_attendance_code_service import UpdateAttendanceCodeService
+from core.application.services.behavior_scales.create_behavior_scale_service import CreateBehaviorScaleService
+from core.application.services.behavior_scales.delete_behavior_scale_service import DeleteBehaviorScaleService
+from core.application.services.behavior_scales.get_behavior_scale_service import GetBehaviorScaleService
+from core.application.services.behavior_scales.list_behavior_scale_service import ListBehaviorScaleService
+from core.application.services.behavior_scales.update_behavior_scale_service import UpdateBehaviorScaleService
 from core.infrastructure.persistence.course_orm_adapter import CourseORMAdapter
 from core.infrastructure.persistence.course_subject_orm_repository import CourseSubjectOrmRepository
 from core.infrastructure.persistence.level_orm_repository import LevelOrmRepository
@@ -45,6 +75,12 @@ from core.infrastructure.persistence.parallel_orm_repository import ParallelORMR
 from core.infrastructure.persistence.school_year_orm_repository import SchoolYearOrmRepository
 from core.infrastructure.persistence.section_orm_repository import SectionOrmRepository
 from core.infrastructure.persistence.subject_orm_repository import SubjectOrmRepository
+from core.infrastructure.persistence.grading_system_orm_repository import GradingSystemOrmRepository
+from core.infrastructure.persistence.grading_term_orm_repository import GradingTermOrmRepository
+from core.infrastructure.persistence.evaluation_type_orm_repository import EvaluationTypeOrmRepository
+from core.infrastructure.persistence.meeting_type_orm_repository import MeetingTypeOrmRepository
+from core.infrastructure.persistence.attendance_code_orm_repository import AttendanceCodeOrmRepository
+from core.infrastructure.persistence.behavior_scale_orm_repository import BehaviorScaleOrmRepository
 from core.application.services.course_subjects.list_from_couse_service import ListFromCourseService
 from core.application.services.course_subjects.remove_range_from_course import RemoveRangeFromCourse
 class Container(containers.DeclarativeContainer):
@@ -55,6 +91,12 @@ class Container(containers.DeclarativeContainer):
     list_parallel_respository = providers.Singleton(ParallelORMRepository)
     school_year_repository = providers.Singleton(SchoolYearOrmRepository)
     section_repository = providers.Singleton(SectionOrmRepository)
+    grading_system_repository = providers.Singleton(GradingSystemOrmRepository)
+    grading_term_repository = providers.Singleton(GradingTermOrmRepository)
+    evaluation_type_repository = providers.Singleton(EvaluationTypeOrmRepository)
+    meeting_type_repository = providers.Singleton(MeetingTypeOrmRepository)
+    attendance_code_repository = providers.Singleton(AttendanceCodeOrmRepository)
+    behavior_scale_repository = providers.Singleton(BehaviorScaleOrmRepository)
     '''
     ==========
     Course Services
@@ -296,5 +338,191 @@ class Container(containers.DeclarativeContainer):
     get_section_service = providers.Factory(
         GetSectionService,
         section_repository=section_repository,
+    )
+
+    '''
+    ==========
+    Grading System Services
+    ==========
+    '''
+
+    create_grading_system_service = providers.Factory(
+        CreateGradingSystemService,
+        grading_system_repository=grading_system_repository,
+    )
+
+    list_grading_system_service = providers.Factory(
+        ListGradingSystemService,
+        grading_system_repository=grading_system_repository,
+    )
+
+    get_grading_system_service = providers.Factory(
+        GetGradingSystemService,
+        grading_system_repository=grading_system_repository,
+    )
+
+    update_grading_system_service = providers.Factory(
+        UpdateGradingSystemService,
+        grading_system_repository=grading_system_repository,
+    )
+
+    delete_grading_system_service = providers.Factory(
+        DeleteGradingSystemService,
+        grading_system_repository=grading_system_repository,
+    )
+
+    '''
+    ==========
+    Grading Term Services
+    ==========
+    '''
+
+    create_grading_term_service = providers.Factory(
+        CreateGradingTermService,
+        grading_term_repository=grading_term_repository,
+    )
+
+    list_grading_term_service = providers.Factory(
+        ListGradingTermService,
+        grading_term_repository=grading_term_repository,
+    )
+
+    get_grading_term_service = providers.Factory(
+        GetGradingTermService,
+        grading_term_repository=grading_term_repository,
+    )
+
+    update_grading_term_service = providers.Factory(
+        UpdateGradingTermService,
+        grading_term_repository=grading_term_repository,
+    )
+
+    delete_grading_term_service = providers.Factory(
+        DeleteGradingTermService,
+        grading_term_repository=grading_term_repository,
+    )
+
+    '''
+    ==========
+    Evaluation Type Services
+    ==========
+    '''
+
+    create_evaluation_type_service = providers.Factory(
+        CreateEvaluationTypeService,
+        evaluation_type_repository=evaluation_type_repository,
+    )
+
+    list_evaluation_type_service = providers.Factory(
+        ListEvaluationTypeService,
+        evaluation_type_repository=evaluation_type_repository,
+    )
+
+    get_evaluation_type_service = providers.Factory(
+        GetEvaluationTypeService,
+        evaluation_type_repository=evaluation_type_repository,
+    )
+
+    update_evaluation_type_service = providers.Factory(
+        UpdateEvaluationTypeService,
+        evaluation_type_repository=evaluation_type_repository,
+    )
+
+    delete_evaluation_type_service = providers.Factory(
+        DeleteEvaluationTypeService,
+        evaluation_type_repository=evaluation_type_repository,
+    )
+
+    '''
+    ==========
+    Meeting Type Services
+    ==========
+    '''
+
+    create_meeting_type_service = providers.Factory(
+        CreateMeetingTypeService,
+        meeting_type_repository=meeting_type_repository,
+    )
+
+    list_meeting_type_service = providers.Factory(
+        ListMeetingTypeService,
+        meeting_type_repository=meeting_type_repository,
+    )
+
+    get_meeting_type_service = providers.Factory(
+        GetMeetingTypeService,
+        meeting_type_repository=meeting_type_repository,
+    )
+
+    update_meeting_type_service = providers.Factory(
+        UpdateMeetingTypeService,
+        meeting_type_repository=meeting_type_repository,
+    )
+
+    delete_meeting_type_service = providers.Factory(
+        DeleteMeetingTypeService,
+        meeting_type_repository=meeting_type_repository,
+    )
+
+    '''
+    ==========
+    Attendance Code Services
+    ==========
+    '''
+
+    create_attendance_code_service = providers.Factory(
+        CreateAttendanceCodeService,
+        attendance_code_repository=attendance_code_repository,
+    )
+
+    list_attendance_code_service = providers.Factory(
+        ListAttendanceCodeService,
+        attendance_code_repository=attendance_code_repository,
+    )
+
+    get_attendance_code_service = providers.Factory(
+        GetAttendanceCodeService,
+        attendance_code_repository=attendance_code_repository,
+    )
+
+    update_attendance_code_service = providers.Factory(
+        UpdateAttendanceCodeService,
+        attendance_code_repository=attendance_code_repository,
+    )
+
+    delete_attendance_code_service = providers.Factory(
+        DeleteAttendanceCodeService,
+        attendance_code_repository=attendance_code_repository,
+    )
+
+    '''
+    ==========
+    Behavior Scale Services
+    ==========
+    '''
+
+    create_behavior_scale_service = providers.Factory(
+        CreateBehaviorScaleService,
+        behavior_scale_repository=behavior_scale_repository,
+    )
+
+    list_behavior_scale_service = providers.Factory(
+        ListBehaviorScaleService,
+        behavior_scale_repository=behavior_scale_repository,
+    )
+
+    get_behavior_scale_service = providers.Factory(
+        GetBehaviorScaleService,
+        behavior_scale_repository=behavior_scale_repository,
+    )
+
+    update_behavior_scale_service = providers.Factory(
+        UpdateBehaviorScaleService,
+        behavior_scale_repository=behavior_scale_repository,
+    )
+
+    delete_behavior_scale_service = providers.Factory(
+        DeleteBehaviorScaleService,
+        behavior_scale_repository=behavior_scale_repository,
     )
     

--- a/core/domain/entities/attendance_code.py
+++ b/core/domain/entities/attendance_code.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class AttendanceCode:
+    id: int
+    code: str
+    description: str
+    affectsGrade: bool
+
+    def __post_init__(self):
+        if not self.code:
+            raise ValueError("Code cannot be empty")
+        if not self.description:
+            raise ValueError("Description cannot be empty")

--- a/core/domain/entities/behavior_scale.py
+++ b/core/domain/entities/behavior_scale.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class BehaviorScale:
+    id: int
+    name: str
+    minScore: float
+    maxScore: float
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("Name cannot be empty")
+        if self.minScore is None or self.maxScore is None:
+            raise ValueError("Scores are required")

--- a/core/domain/entities/evaluation_type.py
+++ b/core/domain/entities/evaluation_type.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class EvaluationType:
+    id: int
+    name: str
+    description: str | None
+    weight: float
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("Name cannot be empty")
+        if self.weight is None:
+            raise ValueError("Weight is required")

--- a/core/domain/entities/grading_system.py
+++ b/core/domain/entities/grading_system.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+@dataclass
+class GradingSystem:
+    id: int
+    name: str
+    description: str | None
+    numberOfTerms: int
+    passingScore: float
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("Name cannot be empty")
+        if self.numberOfTerms is None or self.numberOfTerms <= 0:
+            raise ValueError("Number of terms must be positive")

--- a/core/domain/entities/grading_term.py
+++ b/core/domain/entities/grading_term.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+@dataclass
+class GradingTerm:
+    id: int
+    gradingSystem_id: int
+    academicYear_id: int
+    name: str
+    order: int
+    weight: float
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("Name cannot be empty")
+        if self.order is None or self.order < 0:
+            raise ValueError("Order must be non-negative")
+        if self.weight is None:
+            raise ValueError("Weight is required")

--- a/core/domain/entities/meeting_type.py
+++ b/core/domain/entities/meeting_type.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+@dataclass
+class MeetingType:
+    id: int
+    name: str
+    description: str | None
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError("Name cannot be empty")

--- a/core/domain/repositories/attendance_code_repository.py
+++ b/core/domain/repositories/attendance_code_repository.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.attendance_code import AttendanceCode
+
+class AttendanceCodeRepository(ABC):
+
+    @abstractmethod
+    def get(self, attendance_code_id: int) -> AttendanceCode:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, attendance_code: AttendanceCode) -> AttendanceCode:
+        pass
+
+    @abstractmethod
+    def update(self, attendance_code: AttendanceCode) -> AttendanceCode:
+        pass
+
+    @abstractmethod
+    def delete(self, attendance_code_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_code(self, code: str) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, attendance_code_id: int) -> bool:
+        pass

--- a/core/domain/repositories/behavior_scale_repository.py
+++ b/core/domain/repositories/behavior_scale_repository.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.behavior_scale import BehaviorScale
+
+class BehaviorScaleRepository(ABC):
+
+    @abstractmethod
+    def get(self, behavior_scale_id: int) -> BehaviorScale:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, behavior_scale: BehaviorScale) -> BehaviorScale:
+        pass
+
+    @abstractmethod
+    def update(self, behavior_scale: BehaviorScale) -> BehaviorScale:
+        pass
+
+    @abstractmethod
+    def delete(self, behavior_scale_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_name(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, behavior_scale_id: int) -> bool:
+        pass

--- a/core/domain/repositories/evaluation_type_repository.py
+++ b/core/domain/repositories/evaluation_type_repository.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.evaluation_type import EvaluationType
+
+class EvaluationTypeRepository(ABC):
+
+    @abstractmethod
+    def get(self, evaluation_type_id: int) -> EvaluationType:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, evaluation_type: EvaluationType) -> EvaluationType:
+        pass
+
+    @abstractmethod
+    def update(self, evaluation_type: EvaluationType) -> EvaluationType:
+        pass
+
+    @abstractmethod
+    def delete(self, evaluation_type_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_name(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, evaluation_type_id: int) -> bool:
+        pass

--- a/core/domain/repositories/grading_system_repository.py
+++ b/core/domain/repositories/grading_system_repository.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.grading_system import GradingSystem
+
+class GradingSystemRepository(ABC):
+
+    @abstractmethod
+    def get(self, grading_system_id: int) -> GradingSystem:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, grading_system: GradingSystem) -> GradingSystem:
+        pass
+
+    @abstractmethod
+    def update(self, grading_system: GradingSystem) -> GradingSystem:
+        pass
+
+    @abstractmethod
+    def delete(self, grading_system_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_name(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, grading_system_id: int) -> bool:
+        pass

--- a/core/domain/repositories/grading_term_repository.py
+++ b/core/domain/repositories/grading_term_repository.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.grading_term import GradingTerm
+
+class GradingTermRepository(ABC):
+
+    @abstractmethod
+    def get(self, grading_term_id: int) -> GradingTerm:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, grading_term: GradingTerm) -> GradingTerm:
+        pass
+
+    @abstractmethod
+    def update(self, grading_term: GradingTerm) -> GradingTerm:
+        pass
+
+    @abstractmethod
+    def delete(self, grading_term_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, grading_term_id: int) -> bool:
+        pass

--- a/core/domain/repositories/meeting_type_repository.py
+++ b/core/domain/repositories/meeting_type_repository.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from core.domain.entities.meeting_type import MeetingType
+
+class MeetingTypeRepository(ABC):
+
+    @abstractmethod
+    def get(self, meeting_type_id: int) -> MeetingType:
+        pass
+
+    @abstractmethod
+    def all(self):
+        pass
+
+    @abstractmethod
+    def create(self, meeting_type: MeetingType) -> MeetingType:
+        pass
+
+    @abstractmethod
+    def update(self, meeting_type: MeetingType) -> MeetingType:
+        pass
+
+    @abstractmethod
+    def delete(self, meeting_type_id: int) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_name(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def exist_by_id(self, meeting_type_id: int) -> bool:
+        pass

--- a/core/infrastructure/persistence/attendance_code_orm_repository.py
+++ b/core/infrastructure/persistence/attendance_code_orm_repository.py
@@ -1,0 +1,57 @@
+from core.domain.entities.attendance_code import AttendanceCode
+from core.domain.repositories.attendance_code_repository import AttendanceCodeRepository
+from core.models import AttendanceCodeModel
+from django.utils import timezone
+
+class AttendanceCodeOrmRepository(AttendanceCodeRepository):
+    def get(self, attendance_code_id: int) -> AttendanceCode:
+        model = AttendanceCodeModel.objects.get(id=attendance_code_id, deleted=False)
+        return AttendanceCode(
+            id=model.id,
+            code=model.code,
+            description=model.description,
+            affectsGrade=model.affectsGrade,
+        )
+
+    def all(self):
+        models = AttendanceCodeModel.objects.filter(deleted=False).order_by('code')
+        return [
+            AttendanceCode(
+                id=m.id,
+                code=m.code,
+                description=m.description,
+                affectsGrade=m.affectsGrade,
+            )
+            for m in models
+        ]
+
+    def create(self, attendance_code: AttendanceCode) -> AttendanceCode:
+        model = AttendanceCodeModel(
+            code=attendance_code.code,
+            description=attendance_code.description,
+            affectsGrade=attendance_code.affectsGrade,
+        )
+        model.save()
+        attendance_code.id = model.id
+        return attendance_code
+
+    def update(self, attendance_code: AttendanceCode) -> AttendanceCode:
+        model = AttendanceCodeModel.objects.get(id=attendance_code.id, deleted=False)
+        model.code = attendance_code.code
+        model.description = attendance_code.description
+        model.affectsGrade = attendance_code.affectsGrade
+        model.save()
+        return attendance_code
+
+    def delete(self, attendance_code_id: int) -> bool:
+        model = AttendanceCodeModel.objects.get(id=attendance_code_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_code(self, code: str) -> bool:
+        return AttendanceCodeModel.objects.filter(code=code, deleted=False).exists()
+
+    def exist_by_id(self, attendance_code_id: int) -> bool:
+        return AttendanceCodeModel.objects.filter(id=attendance_code_id, deleted=False).exists()

--- a/core/infrastructure/persistence/behavior_scale_orm_repository.py
+++ b/core/infrastructure/persistence/behavior_scale_orm_repository.py
@@ -1,0 +1,57 @@
+from core.domain.entities.behavior_scale import BehaviorScale
+from core.domain.repositories.behavior_scale_repository import BehaviorScaleRepository
+from core.models import BehaviorScaleModel
+from django.utils import timezone
+
+class BehaviorScaleOrmRepository(BehaviorScaleRepository):
+    def get(self, behavior_scale_id: int) -> BehaviorScale:
+        model = BehaviorScaleModel.objects.get(id=behavior_scale_id, deleted=False)
+        return BehaviorScale(
+            id=model.id,
+            name=model.name,
+            minScore=float(model.minScore),
+            maxScore=float(model.maxScore),
+        )
+
+    def all(self):
+        models = BehaviorScaleModel.objects.filter(deleted=False).order_by('name')
+        return [
+            BehaviorScale(
+                id=m.id,
+                name=m.name,
+                minScore=float(m.minScore),
+                maxScore=float(m.maxScore),
+            )
+            for m in models
+        ]
+
+    def create(self, behavior_scale: BehaviorScale) -> BehaviorScale:
+        model = BehaviorScaleModel(
+            name=behavior_scale.name,
+            minScore=behavior_scale.minScore,
+            maxScore=behavior_scale.maxScore,
+        )
+        model.save()
+        behavior_scale.id = model.id
+        return behavior_scale
+
+    def update(self, behavior_scale: BehaviorScale) -> BehaviorScale:
+        model = BehaviorScaleModel.objects.get(id=behavior_scale.id, deleted=False)
+        model.name = behavior_scale.name
+        model.minScore = behavior_scale.minScore
+        model.maxScore = behavior_scale.maxScore
+        model.save()
+        return behavior_scale
+
+    def delete(self, behavior_scale_id: int) -> bool:
+        model = BehaviorScaleModel.objects.get(id=behavior_scale_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_name(self, name: str) -> bool:
+        return BehaviorScaleModel.objects.filter(name=name, deleted=False).exists()
+
+    def exist_by_id(self, behavior_scale_id: int) -> bool:
+        return BehaviorScaleModel.objects.filter(id=behavior_scale_id, deleted=False).exists()

--- a/core/infrastructure/persistence/evaluation_type_orm_repository.py
+++ b/core/infrastructure/persistence/evaluation_type_orm_repository.py
@@ -1,0 +1,57 @@
+from core.domain.entities.evaluation_type import EvaluationType
+from core.domain.repositories.evaluation_type_repository import EvaluationTypeRepository
+from core.models import EvaluationTypeModel
+from django.utils import timezone
+
+class EvaluationTypeOrmRepository(EvaluationTypeRepository):
+    def get(self, evaluation_type_id: int) -> EvaluationType:
+        model = EvaluationTypeModel.objects.get(id=evaluation_type_id, deleted=False)
+        return EvaluationType(
+            id=model.id,
+            name=model.name,
+            description=model.description,
+            weight=float(model.weight),
+        )
+
+    def all(self):
+        models = EvaluationTypeModel.objects.filter(deleted=False).order_by('name')
+        return [
+            EvaluationType(
+                id=m.id,
+                name=m.name,
+                description=m.description,
+                weight=float(m.weight),
+            )
+            for m in models
+        ]
+
+    def create(self, evaluation_type: EvaluationType) -> EvaluationType:
+        model = EvaluationTypeModel(
+            name=evaluation_type.name,
+            description=evaluation_type.description,
+            weight=evaluation_type.weight,
+        )
+        model.save()
+        evaluation_type.id = model.id
+        return evaluation_type
+
+    def update(self, evaluation_type: EvaluationType) -> EvaluationType:
+        model = EvaluationTypeModel.objects.get(id=evaluation_type.id, deleted=False)
+        model.name = evaluation_type.name
+        model.description = evaluation_type.description
+        model.weight = evaluation_type.weight
+        model.save()
+        return evaluation_type
+
+    def delete(self, evaluation_type_id: int) -> bool:
+        model = EvaluationTypeModel.objects.get(id=evaluation_type_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_name(self, name: str) -> bool:
+        return EvaluationTypeModel.objects.filter(name=name, deleted=False).exists()
+
+    def exist_by_id(self, evaluation_type_id: int) -> bool:
+        return EvaluationTypeModel.objects.filter(id=evaluation_type_id, deleted=False).exists()

--- a/core/infrastructure/persistence/grading_system_orm_repository.py
+++ b/core/infrastructure/persistence/grading_system_orm_repository.py
@@ -1,0 +1,61 @@
+from core.domain.entities.grading_system import GradingSystem
+from core.domain.repositories.grading_system_repository import GradingSystemRepository
+from core.models import GradingSystemModel
+from django.utils import timezone
+
+class GradingSystemOrmRepository(GradingSystemRepository):
+    def get(self, grading_system_id: int) -> GradingSystem:
+        model = GradingSystemModel.objects.get(id=grading_system_id, deleted=False)
+        return GradingSystem(
+            id=model.id,
+            name=model.name,
+            description=model.description,
+            numberOfTerms=model.numberOfTerms,
+            passingScore=float(model.passingScore),
+        )
+
+    def all(self):
+        models = GradingSystemModel.objects.filter(deleted=False).order_by('name')
+        return [
+            GradingSystem(
+                id=m.id,
+                name=m.name,
+                description=m.description,
+                numberOfTerms=m.numberOfTerms,
+                passingScore=float(m.passingScore),
+            )
+            for m in models
+        ]
+
+    def create(self, grading_system: GradingSystem) -> GradingSystem:
+        model = GradingSystemModel(
+            name=grading_system.name,
+            description=grading_system.description,
+            numberOfTerms=grading_system.numberOfTerms,
+            passingScore=grading_system.passingScore,
+        )
+        model.save()
+        grading_system.id = model.id
+        return grading_system
+
+    def update(self, grading_system: GradingSystem) -> GradingSystem:
+        model = GradingSystemModel.objects.get(id=grading_system.id, deleted=False)
+        model.name = grading_system.name
+        model.description = grading_system.description
+        model.numberOfTerms = grading_system.numberOfTerms
+        model.passingScore = grading_system.passingScore
+        model.save()
+        return grading_system
+
+    def delete(self, grading_system_id: int) -> bool:
+        model = GradingSystemModel.objects.get(id=grading_system_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_name(self, name: str) -> bool:
+        return GradingSystemModel.objects.filter(name=name, deleted=False).exists()
+
+    def exist_by_id(self, grading_system_id: int) -> bool:
+        return GradingSystemModel.objects.filter(id=grading_system_id, deleted=False).exists()

--- a/core/infrastructure/persistence/grading_term_orm_repository.py
+++ b/core/infrastructure/persistence/grading_term_orm_repository.py
@@ -1,0 +1,62 @@
+from core.domain.entities.grading_term import GradingTerm
+from core.domain.repositories.grading_term_repository import GradingTermRepository
+from core.models import GradingTermModel
+from django.utils import timezone
+
+class GradingTermOrmRepository(GradingTermRepository):
+    def get(self, grading_term_id: int) -> GradingTerm:
+        model = GradingTermModel.objects.get(id=grading_term_id, deleted=False)
+        return GradingTerm(
+            id=model.id,
+            gradingSystem_id=model.gradingSystem_id,
+            academicYear_id=model.academicYear_id,
+            name=model.name,
+            order=model.order,
+            weight=float(model.weight),
+        )
+
+    def all(self):
+        models = GradingTermModel.objects.filter(deleted=False).order_by('order')
+        return [
+            GradingTerm(
+                id=m.id,
+                gradingSystem_id=m.gradingSystem_id,
+                academicYear_id=m.academicYear_id,
+                name=m.name,
+                order=m.order,
+                weight=float(m.weight),
+            )
+            for m in models
+        ]
+
+    def create(self, grading_term: GradingTerm) -> GradingTerm:
+        model = GradingTermModel(
+            gradingSystem_id=grading_term.gradingSystem_id,
+            academicYear_id=grading_term.academicYear_id,
+            name=grading_term.name,
+            order=grading_term.order,
+            weight=grading_term.weight,
+        )
+        model.save()
+        grading_term.id = model.id
+        return grading_term
+
+    def update(self, grading_term: GradingTerm) -> GradingTerm:
+        model = GradingTermModel.objects.get(id=grading_term.id, deleted=False)
+        model.gradingSystem_id = grading_term.gradingSystem_id
+        model.academicYear_id = grading_term.academicYear_id
+        model.name = grading_term.name
+        model.order = grading_term.order
+        model.weight = grading_term.weight
+        model.save()
+        return grading_term
+
+    def delete(self, grading_term_id: int) -> bool:
+        model = GradingTermModel.objects.get(id=grading_term_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_id(self, grading_term_id: int) -> bool:
+        return GradingTermModel.objects.filter(id=grading_term_id, deleted=False).exists()

--- a/core/infrastructure/persistence/meeting_type_orm_repository.py
+++ b/core/infrastructure/persistence/meeting_type_orm_repository.py
@@ -1,0 +1,53 @@
+from core.domain.entities.meeting_type import MeetingType
+from core.domain.repositories.meeting_type_repository import MeetingTypeRepository
+from core.models import MeetingTypeModel
+from django.utils import timezone
+
+class MeetingTypeOrmRepository(MeetingTypeRepository):
+    def get(self, meeting_type_id: int) -> MeetingType:
+        model = MeetingTypeModel.objects.get(id=meeting_type_id, deleted=False)
+        return MeetingType(
+            id=model.id,
+            name=model.name,
+            description=model.description,
+        )
+
+    def all(self):
+        models = MeetingTypeModel.objects.filter(deleted=False).order_by('name')
+        return [
+            MeetingType(
+                id=m.id,
+                name=m.name,
+                description=m.description,
+            )
+            for m in models
+        ]
+
+    def create(self, meeting_type: MeetingType) -> MeetingType:
+        model = MeetingTypeModel(
+            name=meeting_type.name,
+            description=meeting_type.description,
+        )
+        model.save()
+        meeting_type.id = model.id
+        return meeting_type
+
+    def update(self, meeting_type: MeetingType) -> MeetingType:
+        model = MeetingTypeModel.objects.get(id=meeting_type.id, deleted=False)
+        model.name = meeting_type.name
+        model.description = meeting_type.description
+        model.save()
+        return meeting_type
+
+    def delete(self, meeting_type_id: int) -> bool:
+        model = MeetingTypeModel.objects.get(id=meeting_type_id, deleted=False)
+        model.deleted = True
+        model.deleted_at = timezone.now()
+        model.save()
+        return True
+
+    def exist_by_name(self, name: str) -> bool:
+        return MeetingTypeModel.objects.filter(name=name, deleted=False).exists()
+
+    def exist_by_id(self, meeting_type_id: int) -> bool:
+        return MeetingTypeModel.objects.filter(id=meeting_type_id, deleted=False).exists()

--- a/core/models.py
+++ b/core/models.py
@@ -172,3 +172,101 @@ class ConfigurationModel(BaseModel):
         db_table = 'configuration'
         verbose_name = 'Configuration'
         ordering = ['key']
+
+
+class GradingSystemModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255, unique=True)
+    description = models.TextField(blank=True, null=True)
+    numberOfTerms = models.IntegerField()
+    passingScore = models.DecimalField(max_digits=5, decimal_places=2, default=7.00)
+
+    def __str__(self):
+        return self.name.__str__()
+
+    class Meta:
+        db_table = 'grading_system'
+        verbose_name = 'Grading System'
+        verbose_name_plural = 'Grading Systems'
+        ordering = ['name']
+
+
+class GradingTermModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    gradingSystem = models.ForeignKey(GradingSystemModel, on_delete=models.CASCADE, related_name='terms')
+    academicYear = models.ForeignKey('SchoolYearModel', on_delete=models.CASCADE, related_name='grading_terms')
+    name = models.CharField(max_length=255)
+    order = models.IntegerField()
+    weight = models.DecimalField(max_digits=5, decimal_places=2)
+
+    def __str__(self):
+        return f"{self.gradingSystem.name} - {self.name}"
+
+    class Meta:
+        db_table = 'grading_term'
+        verbose_name = 'Grading Term'
+        verbose_name_plural = 'Grading Terms'
+        ordering = ['order']
+
+
+class EvaluationTypeModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255, unique=True)
+    description = models.TextField(blank=True, null=True)
+    weight = models.DecimalField(max_digits=5, decimal_places=2)
+
+    def __str__(self):
+        return self.name.__str__()
+
+    class Meta:
+        db_table = 'evaluation_type'
+        verbose_name = 'Evaluation Type'
+        verbose_name_plural = 'Evaluation Types'
+        ordering = ['name']
+
+
+class MeetingTypeModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255, unique=True)
+    description = models.TextField(blank=True, null=True)
+
+    def __str__(self):
+        return self.name.__str__()
+
+    class Meta:
+        db_table = 'meeting_type'
+        verbose_name = 'Meeting Type'
+        verbose_name_plural = 'Meeting Types'
+        ordering = ['name']
+
+
+class AttendanceCodeModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    code = models.CharField(max_length=10, unique=True)
+    description = models.CharField(max_length=255)
+    affectsGrade = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f"{self.code} - {self.description}"
+
+    class Meta:
+        db_table = 'attendance_code'
+        verbose_name = 'Attendance Code'
+        verbose_name_plural = 'Attendance Codes'
+        ordering = ['code']
+
+
+class BehaviorScaleModel(BaseModel):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255, unique=True)
+    minScore = models.DecimalField(max_digits=5, decimal_places=2)
+    maxScore = models.DecimalField(max_digits=5, decimal_places=2)
+
+    def __str__(self):
+        return self.name.__str__()
+
+    class Meta:
+        db_table = 'behavior_scale'
+        verbose_name = 'Behavior Scale'
+        verbose_name_plural = 'Behavior Scales'
+        ordering = ['name']

--- a/core/urls.py
+++ b/core/urls.py
@@ -7,6 +7,12 @@ from core.api.views.course_subject_view import CourseSubjectAPIView, CourseSubje
 from core.api.views.parallel_views import ParallelViewSet
 from core.api.views.school_year_views import SchoolYearViewSet
 from core.api.views.section_view import SectionViewSet
+from core.api.views.grading_system_views import GradingSystemViewSet
+from core.api.views.grading_term_views import GradingTermViewSet
+from core.api.views.evaluation_type_views import EvaluationTypeViewSet
+from core.api.views.meeting_type_views import MeetingTypeViewSet
+from core.api.views.attendance_code_views import AttendanceCodeViewSet
+from core.api.views.behavior_scale_views import BehaviorScaleViewSet
 from django.urls import path
 
 router = DefaultRouter()
@@ -17,11 +23,17 @@ router.register(r'course-subjects', CourseSubjectViewSet, basename='course-subje
 router.register(r'parallels', ParallelViewSet, basename='parallels')
 router.register(r'school-years', SchoolYearViewSet, basename='school-years')
 router.register(r'sections', SectionViewSet, basename='sections')
+router.register(r'grading-systems', GradingSystemViewSet, basename='grading-systems')
+router.register(r'grading-terms', GradingTermViewSet, basename='grading-terms')
+router.register(r'evaluation-types', EvaluationTypeViewSet, basename='evaluation-types')
+router.register(r'meeting-types', MeetingTypeViewSet, basename='meeting-types')
+router.register(r'attendance-codes', AttendanceCodeViewSet, basename='attendance-codes')
+router.register(r'behavior-scales', BehaviorScaleViewSet, basename='behavior-scales')
 
 
 
 urlpatterns = [
-    
+
     path('course-subjects/assing/<int:course_id>/', CourseSubjectAPIView.as_view(), name='course-subjects-assign'),
 ]
 urlpatterns += router.urls


### PR DESCRIPTION
## Summary
- add grading related Django models
- wire up repository, serializer, and service layers for new models

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6893a0c0bba4833085d9e5db6ebecf84