### PR TITLE
Add filtering to list endpoints

### DIFF
--- a/core/api/views/academic_planning_views.py
+++ b/core/api/views/academic_planning_views.py
@@ -25,7 +25,18 @@ class AcademicPlanningViewSet(ViewSet):
         return Response(self.serializer_class(planning).data, status=status.HTTP_201_CREATED)
 
     def list(self, request):
-        plannings = self.list_planning_service.execute()
+        course_id = request.query_params.get('course_id', None)
+        parallel_id = request.query_params.get('parallel_id', None)
+        school_year_id = request.query_params.get('school_year_id', None)
+        subject_id = request.query_params.get('subject_id', None)
+        topic = request.query_params.get('topic', None)
+        plannings = self.list_planning_service.execute(
+            course_id=course_id,
+            parallel_id=parallel_id,
+            school_year_id=school_year_id,
+            subject_id=subject_id,
+            topic=topic,
+        )
         paginator = StandardResultsSetPagination(request, plannings)
         paginated_data = paginator.paginate_queryset()
         serializer = self.serializer_class(paginated_data, many=True)

--- a/core/api/views/class_schedule_views.py
+++ b/core/api/views/class_schedule_views.py
@@ -25,7 +25,18 @@ class ClassScheduleViewSet(ViewSet):
         return Response(self.serializer_class(schedule).data, status=status.HTTP_201_CREATED)
 
     def list(self, request):
-        schedules = self.list_schedule_service.execute()
+        course_id = request.query_params.get('course_id', None)
+        parallel_id = request.query_params.get('parallel_id', None)
+        school_year_id = request.query_params.get('school_year_id', None)
+        subject_id = request.query_params.get('subject_id', None)
+        day_of_week = request.query_params.get('day_of_week', None)
+        schedules = self.list_schedule_service.execute(
+            course_id=course_id,
+            parallel_id=parallel_id,
+            school_year_id=school_year_id,
+            subject_id=subject_id,
+            day_of_week=day_of_week,
+        )
         paginator = StandardResultsSetPagination(request, schedules)
         paginated_data = paginator.paginate_queryset()
         serializer = self.serializer_class(paginated_data, many=True)

--- a/core/api/views/course_views.py
+++ b/core/api/views/course_views.py
@@ -46,10 +46,12 @@ class CourseViewSet(ViewSet):
 
     def list(self, request):
         '''
-        List all courses.
+        List all courses with optional filters.
         '''
-        courses = self.list_course_service.execute()
-       
+        name = request.query_params.get('name', None)
+        level_id = request.query_params.get('level_id', None)
+        courses = self.list_course_service.execute(name=name, level_id=level_id)
+
         paginator = StandardResultsSetPagination(request, courses)
         paginated_data = paginator.paginate_queryset()
 

--- a/core/api/views/school_year_views.py
+++ b/core/api/views/school_year_views.py
@@ -34,9 +34,11 @@ class SchoolYearViewSet(ViewSet):
     
     def list(self, request, *args, **kwargs):
         """
-        List all school years.
+        List all school years with optional filters.
         """
-        school_years = self.list_school_year_service.execute()
+        name = request.query_params.get('name', None)
+        status = request.query_params.get('status', None)
+        school_years = self.list_school_year_service.execute(name=name, status=status)
         paginator = StandardResultsSetPagination(request, school_years)
         paginated_data = paginator.paginate_queryset()
 

--- a/core/api/views/subject_views.py
+++ b/core/api/views/subject_views.py
@@ -37,9 +37,11 @@ class SubjectViewSet(ViewSet):
     
     def list(self, request):
         """
-        List all subjects.
+        List all subjects with optional filters.
         """
-        subjects = self.list_subject_service.execute()
+        name = request.query_params.get('name', None)
+        code = request.query_params.get('code', None)
+        subjects = self.list_subject_service.execute(name=name, code=code)
         paginator = StandardResultsSetPagination(request, subjects)
         paginated_data = paginator.paginate_queryset()
 

--- a/core/application/services/academic_plannings/list_academic_planning_service.py
+++ b/core/application/services/academic_plannings/list_academic_planning_service.py
@@ -5,5 +5,20 @@ class ListAcademicPlanningService:
     def __init__(self, academic_planning_repository: AcademicPlanningRepository):
         self.academic_planning_repository = academic_planning_repository
 
-    def execute(self):
-        return self.academic_planning_repository.all()
+    def execute(
+        self,
+        course_id: int = None,
+        parallel_id: int = None,
+        school_year_id: int = None,
+        subject_id: int = None,
+        topic: str = None,
+    ):
+        filters = {
+            "course_id": course_id,
+            "parallel_id": parallel_id,
+            "schoolYear_id": school_year_id,
+            "subject_id": subject_id,
+            "topic__icontains": topic,
+        }
+        filters = {k: v for k, v in filters.items() if v is not None}
+        return self.academic_planning_repository.find_by_filter(**filters)

--- a/core/application/services/class_schedules/list_class_schedule_service.py
+++ b/core/application/services/class_schedules/list_class_schedule_service.py
@@ -5,6 +5,21 @@ class ListClassScheduleService:
     def __init__(self, class_schedule_repository: ClassScheduleRepository):
         self.class_schedule_repository = class_schedule_repository
 
-    def execute(self):
-        return self.class_schedule_repository.all()
+    def execute(
+        self,
+        course_id: int = None,
+        parallel_id: int = None,
+        school_year_id: int = None,
+        subject_id: int = None,
+        day_of_week: str = None,
+    ):
+        filters = {
+            "course_id": course_id,
+            "parallel_id": parallel_id,
+            "schoolYear_id": school_year_id,
+            "subject_id": subject_id,
+            "dayOfWeek": day_of_week,
+        }
+        filters = {k: v for k, v in filters.items() if v is not None}
+        return self.class_schedule_repository.find_by_filter(**filters)
 

--- a/core/application/services/courses/list_course_service.py
+++ b/core/application/services/courses/list_course_service.py
@@ -1,20 +1,34 @@
 from typing import List
+
 from core.domain.entities.course import Course
 from core.domain.repositories.course_repository import CourseRepository
 from rest_framework.exceptions import NotFound, ValidationError
 import logging
+
+
 class ListCourseService:
-    """Service to list all courses."""
-    def __init__(self, course_repository:CourseRepository):
+    """Service to list all courses with optional filters."""
+
+    def __init__(self, course_repository: CourseRepository):
         self.course_repository = course_repository
 
-    def execute(self) -> List[Course]:
-        """Execute the service to list all courses.
+    def execute(self, name: str = None, level_id: int = None) -> List[Course]:
+        """Execute the service to list courses with optional filters.
+
+        Args:
+            name (str, optional): Filter by course name (partial match).
+            level_id (int, optional): Filter by level ID.
+
         Returns:
-            list: A list of all courses.
+            List[Course]: A list of courses matching the filters.
         """
         try:
-            return self.course_repository.all()
+            filters = {
+                "name__icontains": name,
+                "level_id": level_id,
+            }
+            filters = {k: v for k, v in filters.items() if v is not None}
+            return self.course_repository.find_by_filter(**filters)
         except Exception as e:
             logging.error(f"Error listing courses: {e}")
             if isinstance(e, NotFound):

--- a/core/application/services/school_year/list_school_year_service.py
+++ b/core/application/services/school_year/list_school_year_service.py
@@ -5,8 +5,13 @@ from core.domain.repositories.school_year_repository import SchoolYearRepository
 
 
 class ListSchoolYearService:
-    def __init__(self, school_year_repository:SchoolYearRepository):
+    def __init__(self, school_year_repository: SchoolYearRepository):
         self.school_year_repository = school_year_repository
 
-    def execute(self):
-        return self.school_year_repository.all()
+    def execute(self, name: str = None, status: str = None):
+        filters = {
+            "name__icontains": name,
+            "status": status,
+        }
+        filters = {k: v for k, v in filters.items() if v is not None}
+        return self.school_year_repository.find_by_filter(**filters)

--- a/core/application/services/subjects/list_subject_service.py
+++ b/core/application/services/subjects/list_subject_service.py
@@ -1,16 +1,25 @@
 # -*- coding: utf-8 -*-
 from core.domain.repositories.subject_repository import SubjectRepository
-from rest_framework.exceptions import ValidationError, NotFound
-import logging
+
+
 class ListSubjectService:
-    def __init__(self, subject_repository:SubjectRepository):
+    def __init__(self, subject_repository: SubjectRepository):
         self.subject_repository = subject_repository
 
-
-    def execute(self):
+    def execute(self, name: str = None, code: str = None):
         """
-        List all subjects.
+        List subjects applying optional filters.
+
+        Args:
+            name (str, optional): Filter by subject name (partial match).
+            code (str, optional): Filter by subject code (partial match).
+
         Returns:
             list: A list of subject objects.
         """
-        return self.subject_repository.all()
+        filters = {
+            "name__icontains": name,
+            "code__icontains": code,
+        }
+        filters = {k: v for k, v in filters.items() if v is not None}
+        return self.subject_repository.find_by_filter(**filters)

--- a/core/domain/repositories/academic_planning_repository.py
+++ b/core/domain/repositories/academic_planning_repository.py
@@ -36,3 +36,8 @@ class AcademicPlanningRepository(ABC):
         self, parallel_id: int, subject_id: int, start_date: date
     ) -> bool:
         pass
+
+    @abstractmethod
+    def find_by_filter(self, **filters) -> List[AcademicPlanning]:
+        """Find academic plannings by the given filter."""
+        pass

--- a/core/domain/repositories/class_schedule_repository.py
+++ b/core/domain/repositories/class_schedule_repository.py
@@ -39,3 +39,8 @@ class ClassScheduleRepository(ABC):
     def exist_by_parallel_day_time(self, parallel_id: int, day_of_week: str, start_time: time) -> bool:
         pass
 
+    @abstractmethod
+    def find_by_filter(self, **filters) -> List[ClassSchedule]:
+        """Find class schedules by the given filter."""
+        pass
+

--- a/core/domain/repositories/course_repository.py
+++ b/core/domain/repositories/course_repository.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from typing import List
+
 from core.domain.entities.course import Course
 class CourseRepository(ABC):
     
@@ -36,5 +38,10 @@ class CourseRepository(ABC):
     @abstractmethod
     def exist_by_id(self, course_id: str) -> bool:
         """Check if a course exists by its ID."""
+        pass
+
+    @abstractmethod
+    def find_by_filter(self, **filters) -> List[Course]:
+        """Find courses by the given filter."""
         pass
     

--- a/core/domain/repositories/school_year_repository.py
+++ b/core/domain/repositories/school_year_repository.py
@@ -49,3 +49,8 @@ class SchoolYearRepository(ABC):
     def exist_by_name(self, name: str) -> bool:
         """Check if a school year exists by its name."""
         pass
+
+    @abstractmethod
+    def find_by_filter(self, **filters) -> List[SchoolYear]:
+        """Find school years by the given filter."""
+        pass

--- a/core/domain/repositories/subject_repository.py
+++ b/core/domain/repositories/subject_repository.py
@@ -81,5 +81,10 @@ class SubjectRepository(ABC):
             bool: True if the subject exists, False otherwise.
         """
         pass
+
+    @abstractmethod
+    def find_by_filter(self, **filters) -> List[Subject]:
+        """Find subjects by the given filter."""
+        pass
     
     

--- a/core/infrastructure/persistence/academic_planning_orm_repository.py
+++ b/core/infrastructure/persistence/academic_planning_orm_repository.py
@@ -108,3 +108,25 @@ class AcademicPlanningOrmRepository(AcademicPlanningRepository):
             startDate=start_date,
             deleted=False,
         ).exists()
+
+    def find_by_filter(self, **filters):
+        queryset = AcademicPlanningModel.objects.filter(deleted=False)
+        queryset = queryset.filter(**filters).order_by('id')
+        return [
+            AcademicPlanning(
+                id=p.id,
+                course_id=p.course.id,
+                parallel_id=p.parallel.id,
+                school_year_id=p.schoolYear.id,
+                subject_id=p.subject.id,
+                topic=p.topic,
+                start_date=p.startDate,
+                end_date=p.endDate,
+                description=p.description or '',
+                course=p.course,
+                parallel=p.parallel,
+                school_year=p.schoolYear,
+                subject=p.subject,
+            )
+            for p in queryset
+        ]

--- a/core/infrastructure/persistence/class_schedule_orm_repository.py
+++ b/core/infrastructure/persistence/class_schedule_orm_repository.py
@@ -120,3 +120,21 @@ class ClassScheduleOrmRepository(ClassScheduleRepository):
             school_year=schedule.schoolYear,
             subject=schedule.subject,
         ) for schedule in schedules]
+
+    def find_by_filter(self, **filters):
+        queryset = ClassScheduleModel.objects.filter(deleted=False)
+        queryset = queryset.filter(**filters).order_by('id')
+        return [ClassSchedule(
+            id=schedule.id,
+            course_id=schedule.course.id,
+            parallel_id=schedule.parallel.id,
+            school_year_id=schedule.schoolYear.id,
+            subject_id=schedule.subject.id,
+            day_of_week=schedule.dayOfWeek,
+            start_time=schedule.startTime,
+            end_time=schedule.endTime,
+            course=schedule.course,
+            parallel=schedule.parallel,
+            school_year=schedule.schoolYear,
+            subject=schedule.subject,
+        ) for schedule in queryset]

--- a/core/infrastructure/persistence/course_orm_adapter.py
+++ b/core/infrastructure/persistence/course_orm_adapter.py
@@ -58,3 +58,14 @@ class CourseORMAdapter(CourseRepository):
     
     def exist_by_id(self, course_id: str) -> bool:
         return CourseModel.objects.filter(id=course_id, deleted=False).exists()
+
+    def find_by_filter(self, **filters):
+        queryset = CourseModel.objects.filter(deleted=False)
+        queryset = queryset.filter(**filters).order_by('id')
+        return [Course(
+            id=course.id,
+            name=course.name,
+            level_id=course.level.id,
+            description=course.description,
+            level=course.level
+        ) for course in queryset]

--- a/core/infrastructure/persistence/school_year_orm_repository.py
+++ b/core/infrastructure/persistence/school_year_orm_repository.py
@@ -111,3 +111,17 @@ class SchoolYearOrmRepository(SchoolYearRepository):
 
     def exist_by_name(self, name):
         return SchoolYearModel.objects.filter(name=name, deleted=False).exists()
+
+    def find_by_filter(self, **filters):
+        queryset = SchoolYearModel.objects.filter(deleted=False)
+        queryset = queryset.filter(**filters).order_by('id')
+        return [
+            SchoolYear(
+                id=school_year.id,
+                name=school_year.name,
+                startDate=school_year.startDate,
+                endDate=school_year.endDate,
+                status=school_year.status,
+            )
+            for school_year in queryset
+        ]

--- a/core/infrastructure/persistence/subject_orm_repository.py
+++ b/core/infrastructure/persistence/subject_orm_repository.py
@@ -82,4 +82,15 @@ class SubjectOrmRepository(SubjectRepository):
     def exist_by_id(self, subject_id: int) -> bool:
         """Check if a subject exists by its ID."""
         return SubjectModel.objects.filter(id=subject_id, deleted=False).exists()
+
+    def find_by_filter(self, **filters):
+        queryset = SubjectModel.objects.filter(deleted=False)
+        queryset = queryset.filter(**filters).order_by('id')
+        return [Subject(
+            id=subject.id,
+            name=subject.name,
+            description=subject.description,
+            code=subject.code,
+            hoursPerWeek=subject.hoursPerWeek
+        ) for subject in queryset]
     


### PR DESCRIPTION
## Summary
- allow listing courses, subjects, school years, class schedules and academic plans with optional query filters
- add generic filter support in repositories and services

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689d348d831883309f606f229015a832